### PR TITLE
Fix recursive search

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,9 +117,9 @@ module.exports = {
 
                 if (obj.hasOwnProperty(key)) {
                     var newKey = key.replace(searchValue, newValue);
+                    if (recursive && (typeof obj[key] == 'object')) obj[newKey] = this.jsonKeyCharReplacing(obj[key], searchValue, newValue, recursive);
                     if (newKey !== key) {
-                        if (recursive) obj[newKey] = this.jsonKeyCharReplacing(obj[key], searchValue, newValue, recursive);
-                        else obj[newKey] = obj[key];
+                        obj[newKey] = obj[key];
                         delete(obj[key]);
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,8 @@ module.exports = {
             for (var key in obj) {
 
                 if (obj.hasOwnProperty(key)) {
-                    var newKey = key.replace(searchValue, newValue);
+                    var regexp = new RegExp(searchValue, 'g');
+                    var newKey = key.replace(regexp, newValue);
                     if (recursive && (typeof obj[key] == 'object')) obj[newKey] = this.jsonKeyCharReplacing(obj[key], searchValue, newValue, recursive);
                     if (newKey !== key) {
                         obj[newKey] = obj[key];

--- a/test/index.js
+++ b/test/index.js
@@ -102,7 +102,13 @@ describe('jsonKeyCharReplacing', function() {
                 }],
                 "test5.con": "hello.man"
             },
-            "test6.con": "hi."
+            "test6.con": "hi.",
+            "test7con": {
+                "test8con": [{
+                    "test9.con": "hello"
+                }],
+                "test10.con": "hello.man"
+            }
         };
         done();
     });
@@ -118,6 +124,8 @@ describe('jsonKeyCharReplacing', function() {
         out = dtools.jsonKeyCharReplacing(testJSON, ".", "_", true);
         out.test2_con["test5_con"].should.be.equal("hello.man");
         out.test2_con.test3_con[0]["test4_con"].should.be.equal("hello");
+        out.test7con.test8con[0]["test9_con"].should.be.equal("hello");
+        out.test7con.test10_con.should.be.equal("hello.man");
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -107,7 +107,7 @@ describe('jsonKeyCharReplacing', function() {
                 "test8con": [{
                     "test9.con": "hello"
                 }],
-                "test10.con": "hello.man"
+                "test.10.con": "hello.man"
             }
         };
         done();
@@ -115,17 +115,17 @@ describe('jsonKeyCharReplacing', function() {
 
 
     it('replace - first level keys', function() {
-        out = dtools.jsonKeyCharReplacing(testJSON, ".", "_", false);
+        out = dtools.jsonKeyCharReplacing(testJSON, "\\.", "_", false);
         out.test2_con["test5.con"].should.be.equal("hello.man");
         out.test6_con.should.be.equal("hi.");
     });
 
     it('replace - all keys', function() {
-        out = dtools.jsonKeyCharReplacing(testJSON, ".", "_", true);
+        out = dtools.jsonKeyCharReplacing(testJSON, "\\.", "_", true);
         out.test2_con["test5_con"].should.be.equal("hello.man");
         out.test2_con.test3_con[0]["test4_con"].should.be.equal("hello");
         out.test7con.test8con[0]["test9_con"].should.be.equal("hello");
-        out.test7con.test10_con.should.be.equal("hello.man");
+        out.test7con.test_10_con.should.be.equal("hello.man");
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -61,7 +61,7 @@ describe('friendlyDateRepresentation', function() {
 
     it('today - hours', function() {
         var d1 = new Date();
-        var d2 = new Date(d1.getTime() - (60 * 1000 * 70));
+        var d2 = new Date(d1.getTime() - (60 * 1000 * 60));
         out = dtools.friendlyDateRepresentation(d2.toISOString());
         out.should.contain("Hace 1 hora");
     });


### PR DESCRIPTION
If parent key hasn't been changed, the function won't search in the child object. It's necessary to search always, even when the parent key doesn't need to be changed.

edit: Added a regular expresion to replace all the ocurrences for the searched value
